### PR TITLE
fix fontsize for cross console dropdown

### DIFF
--- a/app/ui-react/packages/ui/src/index.css
+++ b/app/ui-react/packages/ui/src/index.css
@@ -216,3 +216,11 @@ body {
   background-color: #fafafa;
   border-top: 1px solid #d1d1d1;
 }
+
+button.pf-c-context-selector__toggle > .pf-c-context-selector__toggle-text {
+  font-size: var(--pf-global--spacer--md);
+}
+
+.pf-c-context-selector__menu {
+  font-size: var(--pf-global--spacer--md);
+}


### PR DESCRIPTION
fix the font-size of the context selector in the cross console nav

<img width="609" alt="Screen Shot 2020-04-20 at 2 50 46 PM" src="https://user-images.githubusercontent.com/20118816/79790505-cfaf1380-8319-11ea-8105-b9ce29fc1517.png">
